### PR TITLE
Issue 925: Fix broken example links

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -155,37 +155,31 @@ export default new Vuex.Store({
         title: 'Using node streams',
         description: 'Train neural network using streams',
         link:
-          '//github.com/BrainJS/brain.js/blob/master/examples/javascript/stream-example.js',
-      },
-      {
-        title: 'Using node streams',
-        description: 'Train neural network using streams',
-        link:
-          '//github.com/BrainJS/brain.js/blob/master/examples/javascript/stream-example.js',
+          '//github.com/BrainJS/brain.js-examples/blob/main/src/stream-example.ts',
       },
       {
         title: 'Forecasting',
         description: 'Predict next number, and forecast numbers',
         link:
-          '//github.com/BrainJS/brain.js/blob/master/examples/javascript/predict-numbers.js',
+          'https://github.com/BrainJS/brain.js-examples/blob/main/src/predict-numbers.ts',
       },
       {
         title: 'Maths',
         description: 'Learning math using a recurrent neural network',
         link:
-          '//github.com/BrainJS/brain.js/blob/master/examples/javascript/learn-math.js',
+          'https://github.com/BrainJS/brain.js-examples/blob/main/src/learn-math.ts',
       },
       {
         title: 'Cross Validate',
         description: 'Using cross validation with a feed forward net ',
         link:
-          '//github.com/BrainJS/brain.js/blob/master/examples/javascript/cross-validate.js',
+          'https://github.com/BrainJS/brain.js-examples/blob/main/src/learn-math.ts',
       },
       {
         title: 'GPU powered AI',
         description: 'using the gpu in a browser',
         link:
-          'https://github.com/BrainJS/brain.js/blob/master/examples/javascript/gpu.html',
+          'https://github.com/BrainJS/brain.js-examples/blob/main/src/feed-forward-gpu-xor.ts',
       },
       {
         title: 'Cryotherapy Success Rate Prediction',


### PR DESCRIPTION
Some of the example links are broken on https://brain.js.org/#/examples, so I'm making this pull request in response to https://github.com/BrainJS/brain.js/issues/925  

a chore update  https://github.com/BrainJS/brain.js/commit/812b27dd00f7391ca3be8d98daf14cacf6ce1dd5    broke all the following links which I updated on the 'store':

- Using node streams
github.com/BrainJS/brain.js/blob/master/examples/javascript/stream-example.js
updated to -> github.com/BrainJS/brain.js-examples/blob/main/src/stream-example.ts

- Forecasting
github.com/BrainJS/brain.js/blob/master/examples/javascript/predict-numbers.js
updated to -> github.com/BrainJS/brain.js-examples/blob/main/src/predict-numbers.ts

- Maths
github.com/BrainJS/brain.js/blob/master/examples/javascript/learn-math.js
updated to ->  github.com/BrainJS/brain.js-examples/blob/main/src/learn-math.ts

- Cross Validate
github.com/BrainJS/brain.js/blob/master/examples/javascript/cross-validate.js
updated to -> github.com/BrainJS/brain.js-examples/blob/main/src/cross-validate.ts

- GPU powered AI
github.com/BrainJS/brain.js/blob/master/examples/javascript/gpu.html
updated to -> github.com/BrainJS/brain.js-examples/blob/main/src/feed-forward-gpu-xor.ts


Also For some reason "using node streams" was repeated twice (there were two duplicate links side-by-side on site) so i removed that duplicate




Unfortunately I only can update to the typescript examples because the js examples were never coppied when that chore was completed.  Maybe we add the js links back in a future update we can then have the links just point to both the .ts and .js versions. At least the examples wont be broken for now